### PR TITLE
popravka regexa za DL i gramatike za termin

### DIFF
--- a/download-pdfs.py
+++ b/download-pdfs.py
@@ -37,7 +37,7 @@ if response.status_code == 200:
     soup = BeautifulSoup(html, 'html.parser')
 
     # Prvi `li` od koga krećemo ekstrakciju
-    start_a = soup.find('a', href=re.compile(r'ani-\d+\.pdf'))
+    start_a = soup.find('a', href=re.compile(r'[Aa]ni.*\.pdf'))
     start_li = start_a.parent if start_a else None
 
     hrefs = []

--- a/raspored/raspored.tx
+++ b/raspored/raspored.tx
@@ -49,4 +49,4 @@ Vrsta: 'rač.vežbe'
      | 'lab.vežbe'
      | 'Pred.';
 Predmet[noskipws]: /\s*/- (!KrajTermina /\w+|\n|./)+;
-KrajTermina: Grupa | Dan | Datum | 'Rasporedi i realizacija' | 'Predmeti za koje nastavu' | 'filename:';
+KrajTermina: Grupa | Dan | Datum | 'Rasporedi i realizacija' | 'Predmeti za koje nastavu' | 'Fakultet tehničkih nauka' | 'filename:';


### PR DESCRIPTION
Stavljen malo slobodniji regex, jer prethodni nije radio.

Primetio sam i da pokupi header naredne stranice kada je termin na kraju stranice.
<img width="1912" height="125" alt="image" src="https://github.com/user-attachments/assets/90e9d2d9-6914-4fe0-ab0d-f2446e41809c" />
Dodat taj string u gramatiku da oznacava kraj termina.